### PR TITLE
[MMCA-4104]  - Update version & configuration for CDS Financials service - July - V4

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.15.0"
+  val bootstrapVersion = "7.19.0"
 
   val compile = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapVersion,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,9 +3,9 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.19.0"
+  private val bootstrapVersion = "7.19.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapVersion,
     "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.14.0-play-28",
     "org.typelevel" %% "cats-core" % "2.3.0",
@@ -15,7 +15,7 @@ object AppDependencies {
     "uk.gov.hmrc" %% "tax-year" % "3.2.0"
   )
 
-  val test = Seq(
+  val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-test-play-28" % bootstrapVersion % Test,
     "org.scalatest" %% "scalatest" % "3.2.9" % Test,
     "org.jsoup" % "jsoup" % "1.10.2" % Test,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,18 +3,20 @@ import sbt._
 
 object AppDependencies {
 
+  val bootstrapVersion = "7.15.0"
+
   val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "7.15.0",
-    "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.7.0-play-28",
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % bootstrapVersion,
+    "uk.gov.hmrc" %% "play-frontend-hmrc" % "7.14.0-play-28",
     "org.typelevel" %% "cats-core" % "2.3.0",
     "com.typesafe.play" %% "play-json-joda" % "2.9.2",
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "1.2.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "1.3.0",
     "org.webjars.npm" % "moment" % "2.29.1",
     "uk.gov.hmrc" %% "tax-year" % "3.2.0"
   )
 
   val test = Seq(
-    "uk.gov.hmrc" %% "bootstrap-test-play-28" % "7.15.0" % Test,
+    "uk.gov.hmrc" %% "bootstrap-test-play-28" % bootstrapVersion % Test,
     "org.scalatest" %% "scalatest" % "3.2.9" % Test,
     "org.jsoup" % "jsoup" % "1.10.2" % Test,
     "com.typesafe.play" %% "play-test" % current % Test,


### PR DESCRIPTION
Description - HMRC library version updates to the latest 

Below libraries have been updated to the latest 

uk.gov.hmrc:bootstrap-backend-play-28
uk.gov.hmrc:bootstrap-test-play-28
uk.gov.hmrc.mongo:hmrc-mongo-play-28
uk.gov.hmrc:play-frontend-hmrc