### PR TITLE
MMCA-5087 Remove Retrievals.name value as it is deprecated

### DIFF
--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -47,15 +47,15 @@ class AuthenticatedIdentifierAction @Inject() (
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
     authorised().retrieve(
-      Retrievals.credentials and Retrievals.name and Retrievals.email
+      Retrievals.credentials and Retrievals.email
         and Retrievals.affinityGroup and Retrievals.internalId and Retrievals.allEnrolments
     ) {
-      case Some(_) ~ _ ~ _ ~ Some(_) ~ Some(_) ~ allEnrolments =>
+      case Some(_) ~ _ ~ Some(_) ~ Some(_) ~ allEnrolments =>
         allEnrolments.getEnrolment("HMRC-CUS-ORG").flatMap(_.getIdentifier("EORINumber")) match {
           case Some(eori) => block(IdentifierRequest(request, eori.value))
           case None       => Future.successful(Redirect(routes.UnauthorisedController.onPageLoad))
         }
-      case _                                                   => throw InsufficientEnrolments()
+      case _                                               => throw InsufficientEnrolments()
     } recover {
       case _: NoActiveSession        =>
         Redirect(config.loginUrl, Map("continue_url" -> Seq(config.loginContinueUrl)))


### PR DESCRIPTION
The value is not used in any way, neither checking the state of the option wrapper or being called anywhere.