### PR TITLE
MMCA-5197 Use HMRC library crypto package to encrypt values going into db

### DIFF
--- a/app/crypto/CryptoAdapter.scala
+++ b/app/crypto/CryptoAdapter.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crypto
+
+import play.api.Configuration
+import play.api.libs.json.*
+import uk.gov.hmrc.crypto.{Crypted, PlainText, SymmetricCryptoFactory}
+
+import javax.inject.Inject
+
+class CryptoAdapter @Inject() (config: Configuration, deprecatedAesGCMCrypto: AesGCMCrypto) {
+
+  private val encryptionKey = config.get[String]("mongodb.encryptionKey")
+  private val crypto        = SymmetricCryptoFactory.aesGcmCrypto(encryptionKey)
+
+  def encrypt(plainText: String): Either[EncryptedValue, Crypted] =
+    Right(crypto.encrypt(PlainText(plainText)))
+
+  def decrypt(encryptedData: Either[EncryptedValue, Crypted]): String = encryptedData match {
+    case Left(legacy)   =>
+      deprecatedAesGCMCrypto.decrypt(legacy, encryptionKey)
+    case Right(crypted) =>
+      crypto.decrypt(crypted).value
+  }
+}
+
+object CryptoAdapterFormats {
+
+  implicit val cryptedformat: OFormat[Crypted] = Json.format[Crypted]
+
+  implicit val eitherFormat: OFormat[Either[EncryptedValue, Crypted]] = new OFormat[Either[EncryptedValue, Crypted]] {
+    override def writes(either: Either[EncryptedValue, Crypted]): JsObject = either match {
+      case Right(crypted) => cryptedformat.writes(crypted)
+      case Left(_)        => throw new IllegalStateException("Legacy format should never be written")
+    }
+
+    override def reads(json: JsValue): JsResult[Either[EncryptedValue, Crypted]] =
+      json.validate[EncryptedValue] match {
+        case JsSuccess(encryptedValue, _) => JsSuccess(Left(encryptedValue))
+        case JsError(_)                   =>
+          json.validate[Crypted] match {
+            case JsSuccess(crypted, _) => JsSuccess(Right(crypted))
+            case JsError(_)            => JsError("Invalid encrypted format")
+          }
+      }
+  }
+}

--- a/app/crypto/GuaranteeTransactionsEncryptor.scala
+++ b/app/crypto/GuaranteeTransactionsEncryptor.scala
@@ -16,17 +16,17 @@
 
 package crypto
 
-import models._
+import models.*
+import uk.gov.hmrc.crypto.Crypted
 
 import javax.inject.Inject
 
-class GuaranteeTransactionsEncryptor @Inject() (crypto: AesGCMCrypto) {
+class GuaranteeTransactionsEncryptor @Inject() (crypto: CryptoAdapter) {
 
   def encryptGuaranteeTransactions(
-    guaranteeTransactions: Seq[GuaranteeTransaction],
-    key: String
+    guaranteeTransactions: Seq[GuaranteeTransaction]
   ): Seq[EncryptedGuaranteeTransaction] = {
-    def e(field: String): EncryptedValue = crypto.encrypt(field, key)
+    def e(field: String): Either[EncryptedValue, Crypted] = crypto.encrypt(field)
 
     guaranteeTransactions.map { transaction =>
       EncryptedGuaranteeTransaction(
@@ -41,26 +41,26 @@ class GuaranteeTransactionsEncryptor @Inject() (crypto: AesGCMCrypto) {
         dischargedAmount = e(transaction.dischargedAmount.toString),
         interestCharge = transaction.interestCharge.map(e),
         c18Reference = transaction.c18Reference.map(e),
-        dueDates = encryptDueDates(transaction.dueDates, key)
+        dueDates = encryptDueDates(transaction.dueDates)
       )
     }
   }
 
-  private def encryptDueDates(dueDates: Seq[DueDate], key: String): Seq[EncryptedDueDate] = {
-    def e(field: String): EncryptedValue = crypto.encrypt(field, key)
+  private def encryptDueDates(dueDates: Seq[DueDate]): Seq[EncryptedDueDate] = {
+    def e(field: String): Either[EncryptedValue, Crypted] = crypto.encrypt(field)
 
     dueDates.map { dueDate =>
       EncryptedDueDate(
         dueDate = e(dueDate.dueDate),
         reasonForSecurity = dueDate.reasonForSecurity.map(e),
-        amounts = encryptAmounts(dueDate.amounts, key),
-        taxTypeGroups = dueDate.taxTypeGroups.map(group => encryptTaxTypeGroups(group, key))
+        amounts = encryptAmounts(dueDate.amounts),
+        taxTypeGroups = dueDate.taxTypeGroups.map(group => encryptTaxTypeGroups(group))
       )
     }
   }
 
-  private def encryptAmounts(amounts: Amounts, key: String): EncryptedAmounts = {
-    def e(field: String): EncryptedValue = crypto.encrypt(field, key)
+  private def encryptAmounts(amounts: Amounts): EncryptedAmounts = {
+    def e(field: String): Either[EncryptedValue, Crypted] = crypto.encrypt(field)
 
     EncryptedAmounts(
       totalAmount = e(amounts.totalAmount),
@@ -70,22 +70,22 @@ class GuaranteeTransactionsEncryptor @Inject() (crypto: AesGCMCrypto) {
     )
   }
 
-  private def encryptTaxTypeGroups(taxTypeGroup: TaxTypeGroup, key: String): EncryptedTaxTypeGroup = {
-    def e(field: String): EncryptedValue = crypto.encrypt(field, key)
+  private def encryptTaxTypeGroups(taxTypeGroup: TaxTypeGroup): EncryptedTaxTypeGroup = {
+    def e(field: String): Either[EncryptedValue, Crypted] = crypto.encrypt(field)
 
     EncryptedTaxTypeGroup(
       taxTypeGroup = e(taxTypeGroup.taxTypeGroup),
-      amounts = encryptAmounts(taxTypeGroup.amounts, key),
-      taxType = encryptTaxType(taxTypeGroup.taxType, key)
+      amounts = encryptAmounts(taxTypeGroup.amounts),
+      taxType = encryptTaxType(taxTypeGroup.taxType)
     )
   }
 
-  private def encryptTaxType(taxType: TaxType, key: String): EncryptedTaxType = {
-    def e(field: String): EncryptedValue = crypto.encrypt(field, key)
+  private def encryptTaxType(taxType: TaxType): EncryptedTaxType = {
+    def e(field: String): Either[EncryptedValue, Crypted] = crypto.encrypt(field)
 
     EncryptedTaxType(
       taxType = e(taxType.taxType),
-      amounts = encryptAmounts(taxType.amounts, key)
+      amounts = encryptAmounts(taxType.amounts)
     )
   }
 }

--- a/app/models/EncryptedGuaranteeTransaction.scala
+++ b/app/models/EncryptedGuaranteeTransaction.scala
@@ -18,43 +18,50 @@ package models
 
 import crypto.EncryptedValue
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.crypto.Crypted
 
 import java.time.LocalDate
 
 case class EncryptedAmounts(
-  totalAmount: EncryptedValue,
-  clearedAmount: Option[EncryptedValue],
-  openAmount: Option[EncryptedValue],
-  updateDate: EncryptedValue
+  totalAmount: Either[EncryptedValue, Crypted],
+  clearedAmount: Option[Either[EncryptedValue, Crypted]],
+  openAmount: Option[Either[EncryptedValue, Crypted]],
+  updateDate: Either[EncryptedValue, Crypted]
 )
 
 case class EncryptedDueDate(
-  dueDate: EncryptedValue,
-  reasonForSecurity: Option[EncryptedValue],
+  dueDate: Either[EncryptedValue, Crypted],
+  reasonForSecurity: Option[Either[EncryptedValue, Crypted]],
   amounts: EncryptedAmounts,
   taxTypeGroups: Seq[EncryptedTaxTypeGroup]
 )
 
-case class EncryptedTaxTypeGroup(taxTypeGroup: EncryptedValue, amounts: EncryptedAmounts, taxType: EncryptedTaxType)
+case class EncryptedTaxTypeGroup(
+  taxTypeGroup: Either[EncryptedValue, Crypted],
+  amounts: EncryptedAmounts,
+  taxType: EncryptedTaxType
+)
 
-case class EncryptedTaxType(taxType: EncryptedValue, amounts: EncryptedAmounts)
+case class EncryptedTaxType(taxType: Either[EncryptedValue, Crypted], amounts: EncryptedAmounts)
 
 case class EncryptedGuaranteeTransaction(
   date: LocalDate,
-  movementReferenceNumber: EncryptedValue,
+  movementReferenceNumber: Either[EncryptedValue, Crypted],
   secureMovementReferenceNumber: Option[String],
-  balance: EncryptedValue,
-  uniqueConsignmentReference: Option[EncryptedValue],
-  declarantEori: EncryptedValue,
-  consigneeEori: EncryptedValue,
-  originalCharge: EncryptedValue,
-  dischargedAmount: EncryptedValue,
-  interestCharge: Option[EncryptedValue],
-  c18Reference: Option[EncryptedValue],
+  balance: Either[EncryptedValue, Crypted],
+  uniqueConsignmentReference: Option[Either[EncryptedValue, Crypted]],
+  declarantEori: Either[EncryptedValue, Crypted],
+  consigneeEori: Either[EncryptedValue, Crypted],
+  originalCharge: Either[EncryptedValue, Crypted],
+  dischargedAmount: Either[EncryptedValue, Crypted],
+  interestCharge: Option[Either[EncryptedValue, Crypted]],
+  c18Reference: Option[Either[EncryptedValue, Crypted]],
   dueDates: Seq[EncryptedDueDate]
 )
 
 object EncryptedGuaranteeTransaction {
+  import crypto.CryptoAdapterFormats.eitherFormat
+
   implicit val amountFormat: OFormat[EncryptedAmounts]            = Json.format[EncryptedAmounts]
   implicit val taxTypeFormat: OFormat[EncryptedTaxType]           = Json.format[EncryptedTaxType]
   implicit val taxTypeGroupFormat: OFormat[EncryptedTaxTypeGroup] = Json.format[EncryptedTaxTypeGroup]

--- a/app/repositories/CacheRepository.scala
+++ b/app/repositories/CacheRepository.scala
@@ -57,19 +57,17 @@ class DefaultCacheRepository @Inject() (
     )
     with CacheRepository {
 
-  private val encryptionKey = config.get[String]("mongodb.encryptionKey")
-
   def get(id: String): Future[Option[Seq[GuaranteeTransaction]]] =
     for {
       result <- collection.find(equal("_id", id)).toSingle().toFutureOption()
       account = result.map(mongoAccount =>
-                  guaranteeTransactionsDecryptor.decryptGuaranteeTransactions(mongoAccount.transactions, encryptionKey)
+                  guaranteeTransactionsDecryptor.decryptGuaranteeTransactions(mongoAccount.transactions)
                 )
     } yield account
 
   def set(id: String, transactions: Seq[GuaranteeTransaction]): Future[Boolean] = {
     val record = GuaranteeAccountMongo(
-      guaranteeTransactionsEncryptor.encryptGuaranteeTransactions(transactions, encryptionKey),
+      guaranteeTransactionsEncryptor.encryptGuaranteeTransactions(transactions),
       Instant.now()
     )
 

--- a/test/crypto/CryptoAdapterSpec.scala
+++ b/test/crypto/CryptoAdapterSpec.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crypto
+
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.*
+import play.api.inject
+import play.api.libs.json.*
+import uk.gov.hmrc.crypto.Crypted
+import utils.SpecBase
+
+class CryptoAdapterSpec extends SpecBase {
+
+  "CryptoAdapter" should {
+    "encrypt a plaintext string" in new Setup {
+      val result = adapter.encrypt(plaintext)
+
+      result.isRight mustBe true
+    }
+
+    "decrypt a Right(Crypted(...)) with the new approach" in new Setup {
+      val crypted   = adapter.encrypt(plaintext)
+      val decrypted = adapter.decrypt(crypted)
+
+      decrypted mustBe plaintext
+      verify(mockAesGCM, never()).decrypt(any(), any())
+    }
+
+    "decrypt a Left(EncryptedValue(...)) with the deprecated approach" in new Setup {
+      val legacyValue = EncryptedValue(cipherText, nonce)
+      when(mockAesGCM.decrypt(eqTo(legacyValue), any())).thenReturn(plaintext)
+
+      val decrypted = adapter.decrypt(Left(legacyValue))
+
+      decrypted mustBe plaintext
+      verify(mockAesGCM).decrypt(eqTo(legacyValue), any())
+    }
+  }
+
+  "CryptoAdapterFormats" should {
+    import crypto.CryptoAdapterFormats.*
+
+    "read legacy EncryptedValue as Left(...)" in new Setup {
+      val json = Json.parse(s"""{"value":"$cipherText","nonce":"$nonce"}""")
+      val res  = json.validate[Either[EncryptedValue, Crypted]](eitherFormat)
+
+      res.isSuccess mustBe true
+      res.get.swap.toOption.get.value mustBe cipherText
+      res.get.swap.toOption.get.nonce mustBe nonce
+    }
+
+    "read Crypted as Right(...)" in new Setup {
+      val json = Json.parse(s"""{"value":"$cipherText"}""")
+      val res  = json.validate[Either[EncryptedValue, Crypted]](eitherFormat)
+
+      res.isSuccess mustBe true
+      res.get.toOption.get.value mustBe cipherText
+    }
+
+    "fail to read invalid JSON" in {
+      val json = Json.parse("""{"x":"???"}""")
+      val res  = json.validate[Either[EncryptedValue, Crypted]](eitherFormat)
+
+      res.isError mustBe true
+    }
+
+    "write a Right(Crypted(...)) as JSON" in new Setup {
+      val crypted = Crypted(cipherText)
+      val json    = Json.toJson(Right(crypted))(eitherFormat)
+
+      (json \ "value").as[String] mustBe cipherText
+    }
+
+    "throw exception when writing Left(EncryptedValue(...))" in new Setup {
+      val leftVal = Left(EncryptedValue(cipherText, nonce))
+
+      an[IllegalStateException] mustBe thrownBy {
+        Json.toJson(leftVal)(eitherFormat)
+      }
+    }
+  }
+
+  trait Setup {
+    protected val mockAesGCM: AesGCMCrypto = mock[AesGCMCrypto]
+
+    private val app = applicationBuilder
+      .overrides(
+        Seq(
+          inject.bind[AesGCMCrypto].to(mockAesGCM)
+        )
+      )
+      .build()
+
+    protected val adapter: CryptoAdapter = app.injector.instanceOf[CryptoAdapter]
+
+    protected val plaintext  = "plaintext"
+    protected val cipherText = "ciphertext"
+    protected val nonce      = "nonce"
+  }
+}

--- a/test/crypto/GuaranteeTransactionsEncryptionSpec.scala
+++ b/test/crypto/GuaranteeTransactionsEncryptionSpec.scala
@@ -17,7 +17,6 @@
 package crypto
 
 import models.*
-import play.api.Configuration
 import play.api.test.Helpers.running
 import utils.SpecBase
 import utils.TestData.{dayTwentyTwo, year_2019}
@@ -49,12 +48,10 @@ class GuaranteeTransactionsEncryptionSpec extends SpecBase {
 
     val encryptor = instanceOf[GuaranteeTransactionsEncryptor]
     val decryptor = instanceOf[GuaranteeTransactionsDecryptor]
-    val config    = instanceOf[Configuration]
-    val key       = config.get[String]("mongodb.encryptionKey")
 
     running(application) {
-      val encrypted = encryptor.encryptGuaranteeTransactions(Seq(transaction), key)
-      decryptor.decryptGuaranteeTransactions(encrypted, key) mustBe Seq(transaction)
+      val encrypted = encryptor.encryptGuaranteeTransactions(Seq(transaction))
+      decryptor.decryptGuaranteeTransactions(encrypted) mustBe Seq(transaction)
     }
   }
 }

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -16,9 +16,8 @@
 
 package utils
 
-import crypto.EncryptedValue
-import uk.gov.hmrc.http.SessionId
 import models.*
+import uk.gov.hmrc.http.SessionId
 
 import java.time.{LocalDate, LocalDateTime, ZoneOffset}
 
@@ -77,6 +76,4 @@ object TestData {
   val encryptedValue     = "sTe+0SVx5j5y509Nq8tIyflvnsRMfMC5Ae03fNUEarI="
   val nonceValue: String = "RosGoD7PB/RGTz9uYEvU86zB/LxuWRUGQ2ay9PYbqWBKgy1Jy+j+REmx+cp74VhtvTrfFttQv4ArHUc/1tMyl3" +
     "fGz3/cr8Tm1BHzanv659kI2MJqMynltIsY9fqdDpmO"
-
-  val encryptedValueObject: EncryptedValue = EncryptedValue(encryptedValue, nonceValue)
 }


### PR DESCRIPTION
- [ ] Add CryptoAdapter class
- [ ] Add spec for it
- [ ] Update other specs to handle new types
- [ ] Expand Cache RepositorySpec to test both formats
- [ ] Acceptance test run
- [ ] Tested manually to check old values can be properly decrypted when this is deployed.