### PR TITLE
MMCA-5288 Add pre-populated answers on request transactions journey w…

### DIFF
--- a/app/controllers/DownloadCsvController.scala
+++ b/app/controllers/DownloadCsvController.scala
@@ -28,6 +28,7 @@ import play.api.Logger
 import play.api.i18n.{I18nSupport, Messages}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Request, Result}
 import services.{AuditingService, DateTimeService}
+import repositories.RequestedTransactionsCache
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import viewmodels.GuaranteeTransactionCsvRow.GuaranteeTransactionCsvRowViewModel
 import viewmodels.{CSVWriter, ResultsPageSummary}
@@ -49,6 +50,7 @@ class DownloadCsvController @Inject() (
   tooManyResults: guarantee_transactions_too_many_results,
   noResults: guarantee_transactions_no_result,
   auditingService: AuditingService,
+  cache: RequestedTransactionsCache,
   unableToDownloadCSV: guarantee_account_unable_download_csv,
   notFound: not_found
 )(implicit
@@ -143,6 +145,8 @@ class DownloadCsvController @Inject() (
     accountNumber: String,
     eori: String
   )(implicit request: Request[_]): Result =
+    cache.clear(eori)
+
     transactions match {
       case Left(error) =>
         error match {

--- a/app/controllers/RequestTransactionsController.scala
+++ b/app/controllers/RequestTransactionsController.scala
@@ -47,10 +47,16 @@ class RequestTransactionsController @Inject() (
   def form: Form[GuaranteeTransactionDates] = formProvider()
 
   def onPageLoad(): Action[AnyContent] = (identify andThen checkEmailIsVerified).async { implicit request =>
-    cache.get(request.eori).recover { case _ => None }.map {
-      case Some(cachedData) => Ok(view(form.fill(cachedData)))
-      case None             => Ok(view(form))
-    }
+    cache
+      .get(request.eori)
+      .recover { case _ =>
+        log.warn("Failed retrieval of requested transactions dates from cache")
+        None
+      }
+      .map {
+        case Some(cachedData) => Ok(view(form.fill(cachedData)))
+        case None             => Ok(view(form))
+      }
   }
 
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>

--- a/app/controllers/RequestTransactionsController.scala
+++ b/app/controllers/RequestTransactionsController.scala
@@ -47,9 +47,10 @@ class RequestTransactionsController @Inject() (
   def form: Form[GuaranteeTransactionDates] = formProvider()
 
   def onPageLoad(): Action[AnyContent] = (identify andThen checkEmailIsVerified).async { implicit request =>
-    for {
-      _ <- cache.clear(request.eori)
-    } yield Ok(view(form))
+    cache.get(request.eori).recover { case _ => None }.map {
+      case Some(cachedData) => Ok(view(form.fill(cachedData)))
+      case None             => Ok(view(form))
+    }
   }
 
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>

--- a/test/controllers/DownloadCsvControllerSpec.scala
+++ b/test/controllers/DownloadCsvControllerSpec.scala
@@ -16,26 +16,22 @@
 
 package controllers
 
-import connectors.{
-  AccountStatusOpen, CustomsFinancialsApiConnector, NoTransactionsAvailable, TooManyTransactionsRequested,
-  UnknownException
-}
+import connectors.*
 import models.*
+import org.mockito.ArgumentMatchers.{any, eq as eqTo}
+import org.mockito.Mockito.{verify, when}
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.Application
 import play.api.http.Status
 import play.api.inject.bind
+import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import services.AuditingService
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import uk.gov.hmrc.play.audit.http.connector.AuditResult
 import utils.SpecBase
-import utils.TestData.{balance, dayTwentyThree, dayTwentyTwo, dd, eori, fromDate, limit, someGan, toDate, year_2018}
-import org.mockito.ArgumentMatchers.{any, eq => eqTo}
-import org.mockito.Mockito.when
-import org.mockito.Mockito.verify
-import org.scalatestplus.mockito.MockitoSugar.mock
-import play.api.Application
-import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded}
+import utils.TestData.*
 
 import java.time.{LocalDate, LocalDateTime, Month}
 import scala.concurrent.Future
@@ -271,6 +267,8 @@ class DownloadCsvControllerSpec extends SpecBase {
         val result = route(appRequested, request).value
 
         status(result) mustEqual OK
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 
@@ -310,6 +308,8 @@ class DownloadCsvControllerSpec extends SpecBase {
         status(result) mustBe OK
 
         contentAsString(result) must include regex "No guarantee account securities"
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 
@@ -330,6 +330,8 @@ class DownloadCsvControllerSpec extends SpecBase {
         val result = route(appRequested, request).value
 
         contentAsString(result) must include regex "Your search returned too many results"
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 
@@ -350,6 +352,8 @@ class DownloadCsvControllerSpec extends SpecBase {
         val result = route(appRequested, request).value
 
         status(result) mustBe SEE_OTHER
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 
@@ -370,6 +374,8 @@ class DownloadCsvControllerSpec extends SpecBase {
         val result = route(appRequested, request).value
 
         status(result) mustBe SEE_OTHER
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 
@@ -392,6 +398,8 @@ class DownloadCsvControllerSpec extends SpecBase {
         val result = route(app, request).value
 
         status(result) mustBe SEE_OTHER
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 
@@ -414,6 +422,8 @@ class DownloadCsvControllerSpec extends SpecBase {
         val result = route(app, request).value
 
         redirectLocation(result).value mustEqual routes.DownloadCsvController.showUnableToDownloadCSV(None).url
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 

--- a/test/controllers/DownloadCsvControllerSpec.scala
+++ b/test/controllers/DownloadCsvControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import connectors.*
 import models.*
-import org.mockito.ArgumentMatchers.{any, eq as eqTo}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.{verify, when}
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.Application

--- a/test/controllers/GuaranteeAccountControllerSpec.scala
+++ b/test/controllers/GuaranteeAccountControllerSpec.scala
@@ -16,12 +16,13 @@
 
 package controllers
 
-import connectors.{
-  AccountStatusOpen, CustomsFinancialsApiConnector, NoTransactionsAvailable, TooManyTransactionsRequested,
-  UnknownException
-}
+import connectors.*
 import models.*
 import org.jsoup.Jsoup.parseBodyFragment
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.{verify, when}
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.Application
 import play.api.http.Status
 import play.api.inject.bind
 import play.api.test.FakeRequest
@@ -30,17 +31,11 @@ import services.{AuditingService, DataStoreService, DateTimeService}
 import uk.gov.hmrc.auth.core.retrieve.Email
 import uk.gov.hmrc.http.UpstreamErrorResponse
 import utils.SpecBase
-import utils.TestData.{
-  balance, dayTwenty, dayTwentyOne, dayTwentyThree, dayTwentyTwo, dd, eori, limit, someGan, ten, year_2019, zero
-}
-import org.mockito.ArgumentMatchers.{any, eq => eqTo}
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar.mock
-import play.api.Application
+import utils.TestData.*
 
 import java.time.{LocalDate, LocalDateTime, Month}
-import scala.jdk.CollectionConverters.*
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters.*
 import scala.util.Random
 
 class GuaranteeAccountControllerSpec extends SpecBase {
@@ -75,6 +70,8 @@ class GuaranteeAccountControllerSpec extends SpecBase {
         val result  = route(application, request).value
 
         status(result) mustEqual OK
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 
@@ -105,6 +102,8 @@ class GuaranteeAccountControllerSpec extends SpecBase {
         val result  = route(application, request).value
 
         status(result) mustEqual SEE_OTHER
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 
@@ -137,6 +136,8 @@ class GuaranteeAccountControllerSpec extends SpecBase {
         val result  = route(application, request).value
 
         status(result) mustEqual OK
+
+        verify(mockRequestedTransactionsCache).clear(eqTo(eori))
       }
     }
 

--- a/test/controllers/RequestTransactionControllerSpec.scala
+++ b/test/controllers/RequestTransactionControllerSpec.scala
@@ -16,22 +16,25 @@
 
 package controllers
 
+import models.GuaranteeTransactionDates
 import play.api.test.Helpers.*
 import utils.SpecBase
+
 import java.time.LocalDate
 import scala.concurrent.Future
 import utils.Utils.emptyString
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.{verify, when}
 import play.api.Application
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded}
 import play.api.test.FakeRequest
+import utils.TestData.eori
 
 class RequestTransactionControllerSpec extends SpecBase {
 
   "onPageLoad" should {
     "return OK with pre-populated data" in new Setup {
-      when(mockRequestedTransactionsCache.clear(any)).thenReturn(Future.successful(true))
+      when(mockRequestedTransactionsCache.get(eqTo(eori))).thenReturn(Future.successful(Some(transactionDates)))
 
       val request: FakeRequest[AnyContentAsEmpty.type] =
         fakeRequest(GET, routes.RequestTransactionsController.onPageLoad().url)
@@ -40,11 +43,12 @@ class RequestTransactionControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustBe OK
+        verify(mockRequestedTransactionsCache).get(eqTo(eori))
       }
     }
 
     "return OK with no cached data" in new Setup {
-      when(mockRequestedTransactionsCache.clear(any)).thenReturn(Future.successful(true))
+      when(mockRequestedTransactionsCache.get(eqTo(eori))).thenReturn(Future.successful(None))
 
       val request: FakeRequest[AnyContentAsEmpty.type] =
         fakeRequest(GET, routes.RequestTransactionsController.onPageLoad().url)
@@ -53,24 +57,21 @@ class RequestTransactionControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result) mustBe OK
+        verify(mockRequestedTransactionsCache).get(eqTo(eori))
       }
     }
 
-    "return OK when clearing cache" in new Setup {
-      when(mockRequestedTransactionsCache.clear(any)).thenReturn(Future.successful(true))
+    "return OK when DB get throws exception" in new Setup {
+      when(mockRequestedTransactionsCache.get(eqTo(eori))).thenReturn(Future.failed(new Exception()))
 
-      val store: FakeRequest[AnyContentAsEmpty.type] =
-        fakeRequest(GET, routes.RequestTransactionsController.onSubmit().url)
-
-      val clear: FakeRequest[AnyContentAsEmpty.type] =
+      val request: FakeRequest[AnyContentAsEmpty.type] =
         fakeRequest(GET, routes.RequestTransactionsController.onPageLoad().url)
 
       running(application) {
-        val result = route(application, store).value
-        val test   = route(application, clear).value
+        val test = route(application, request).value
 
-        status(result) mustBe OK
         status(test) mustBe OK
+        verify(mockRequestedTransactionsCache).get(eqTo(eori))
       }
     }
   }
@@ -241,4 +242,9 @@ class RequestTransactionControllerSpec extends SpecBase {
       .configure("features.fixed-systemdate-for-tests" -> "true")
       .build()
   }
+
+  val transactionDates: GuaranteeTransactionDates = GuaranteeTransactionDates(
+    start = LocalDate.of(2021, 3, 1),
+    end = LocalDate.of(2021, 10, 1)
+  )
 }

--- a/test/controllers/RequestTransactionControllerSpec.scala
+++ b/test/controllers/RequestTransactionControllerSpec.scala
@@ -28,7 +28,7 @@ import org.mockito.Mockito.{verify, when}
 import play.api.Application
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded}
 import play.api.test.FakeRequest
-import utils.TestData.eori
+import utils.TestData.{day_20, eori, month_12, month_7, year_2019}
 
 class RequestTransactionControllerSpec extends SpecBase {
 
@@ -244,7 +244,7 @@ class RequestTransactionControllerSpec extends SpecBase {
   }
 
   val transactionDates: GuaranteeTransactionDates = GuaranteeTransactionDates(
-    start = LocalDate.of(2021, 3, 1),
-    end = LocalDate.of(2021, 10, 1)
+    start = LocalDate.of(year_2019, month_7, day_20),
+    end = LocalDate.of(year_2019, month_12, day_20)
   )
 }

--- a/test/utils/SpecBase.scala
+++ b/test/utils/SpecBase.scala
@@ -19,7 +19,7 @@ package utils
 import com.codahale.metrics.MetricRegistry
 import controllers.actions.{FakeIdentifierAction, IdentifierAction}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.OptionValues
+import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -31,6 +31,7 @@ import play.api.test.FakeRequest
 import repositories.{CacheRepository, RequestedTransactionsCache}
 import play.api.Application
 import config.AppConfig
+import org.mockito.Mockito.reset
 import play.api.i18n.{Messages, MessagesApi}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
@@ -50,12 +51,15 @@ trait SpecBase
     with MockitoSugar
     with OptionValues
     with ScalaFutures
-    with IntegrationPatience {
+    with IntegrationPatience
+    with BeforeAndAfterEach {
+
+  override def beforeEach(): Unit = reset(mockRequestedTransactionsCache)
 
   val mockCacheRepository: CacheRepository                       = mock[CacheRepository]
   val mockRequestedTransactionsCache: RequestedTransactionsCache = mock[RequestedTransactionsCache]
 
-  lazy val applicationBuilder: GuiceApplicationBuilder = new GuiceApplicationBuilder()
+  def applicationBuilder: GuiceApplicationBuilder = new GuiceApplicationBuilder()
     .overrides(
       bind[IdentifierAction].to[FakeIdentifierAction],
       bind[MetricRegistry].toInstance(new FakeMetrics),


### PR DESCRIPTION
…hen user goes back

- [x]  Clear cache when user completes journey (clicks on link to download csv)
- [x] Clear cache when user leaves flow (if user reaches /customs/guarantee-account)
- [x] Retrieve dates from cache if user goes back while in flow.