### PR TITLE
MMCA-5403 - Adding role to guarentee account navigation

### DIFF
--- a/app/views/components/pager.scala.html
+++ b/app/views/components/pager.scala.html
@@ -21,7 +21,7 @@
 @(model: Paginated)(implicit messages: Messages)
 
 @if(!model.dataFitsOnOnePage) {
-    <nav class="govuk-pagination" id="pagination-label">
+    <nav class="govuk-pagination" id="pagination-label" role="table-pagination" aria-label="table-pagination">
         <p class="govuk-visually-hidden">Pagination navigation</p>
          @if(!model.isFirstPage) {
             @linkToPreviousPage


### PR DESCRIPTION
https://jira.tools.tax.service.gov.uk/browse/MMCA-5404

There is a role missing from the guarentee account navigation that wraps the table pagination. this PR adds this role so that the accessibility warnings no longer alarm when there is multiple navs on screen at one time 