### PR TITLE
[MMCA 5475] -  Increase test coverage to at-least 90%

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,8 @@
 $govuk-assets-path: "/customs/guarantee-account/assets/lib/govuk-frontend/govuk/assets/";
 $hmrc-assets-path: "/customs/guarantee-account/assets/lib/hmrc-frontend/hmrc/";
 
+$govuk-suppressed-warnings: (libsass);
+
 @import "lib/govuk-frontend/dist/govuk/base";
 
 @import "utils/custom";

--- a/app/connectors/AccountsAndBalances.scala
+++ b/app/connectors/AccountsAndBalances.scala
@@ -150,15 +150,18 @@ case class Limits(periodGuaranteeLimit: String, periodAccountLimit: String)
 case class DefermentBalances(periodAvailableGuaranteeBalance: String, periodAvailableAccountBalance: String)
 
 object AccountsAndBalancesResponseContainer {
-  implicit val returnParametersReads: Reads[ReturnParameters]                                         = Json.reads[ReturnParameters]
-  implicit val accountReads: Reads[Account]                                                           = Json.reads[Account]
-  implicit val limitsReads: Reads[Limits]                                                             = Json.reads[Limits]
-  implicit val balancesReads: Reads[DefermentBalances]                                                = Json.reads[DefermentBalances]
-  implicit val generalGuaranteeAccountReads: Reads[GeneralGuaranteeAccount]                           = Json.reads[GeneralGuaranteeAccount]
-  implicit val accountResponseDetailReads: Reads[AccountResponseDetail]                               = Json.reads[AccountResponseDetail]
-  implicit val accountResponseCommonReads: Reads[AccountResponseCommon]                               = Json.reads[AccountResponseCommon]
-  implicit val accountsAndBalancesResponseReads: Reads[AccountsAndBalancesResponse]                   =
+  implicit val returnParametersReads: Reads[ReturnParameters] = Json.reads[ReturnParameters]
+  implicit val accountReads: Reads[Account]                   = Json.reads[Account]
+  implicit val limitsReads: Reads[Limits]                     = Json.reads[Limits]
+  implicit val balancesReads: Reads[DefermentBalances]        = Json.reads[DefermentBalances]
+
+  implicit val generalGuaranteeAccountReads: Reads[GeneralGuaranteeAccount] = Json.reads[GeneralGuaranteeAccount]
+  implicit val accountResponseDetailReads: Reads[AccountResponseDetail]     = Json.reads[AccountResponseDetail]
+  implicit val accountResponseCommonReads: Reads[AccountResponseCommon]     = Json.reads[AccountResponseCommon]
+
+  implicit val accountsAndBalancesResponseReads: Reads[AccountsAndBalancesResponse] =
     Json.reads[AccountsAndBalancesResponse]
+
   implicit val accountsAndBalancesResponseContainerReads: Reads[AccountsAndBalancesResponseContainer] =
     Json.reads[AccountsAndBalancesResponseContainer]
 }

--- a/app/connectors/FileInformation.scala
+++ b/app/connectors/FileInformation.scala
@@ -26,8 +26,9 @@ case class MetadataItem(key: String, value: String)
 case class Metadata(items: Seq[MetadataItem])
 
 object FileInformation {
-  implicit val metadataItemReads: Reads[MetadataItem]   =
+  implicit val metadataItemReads: Reads[MetadataItem] =
     ((JsPath \ "metadata").read[String] and (JsPath \ "value").read[String])(MetadataItem.apply _)
+
   implicit val metadataReads: Reads[Metadata]           = __.read[List[MetadataItem]].map(Metadata.apply)
   implicit val metadataItemWrites: Writes[MetadataItem] = Json.writes[MetadataItem]
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,7 @@ lazy val microservice = Project(appName, file("."))
         ".*javascript.*;.*Routes.*;.*GuiceInjector;" +
         ".*ControllerConfiguration;.*LanguageSwitchController",
     ScoverageKeys.coverageMinimumStmtTotal := 90,
-    ScoverageKeys.coverageMinimumBranchTotal := 90,
-    ScoverageKeys.coverageFailOnMinimum := false,
+    ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
     TwirlKeys.templateImports ++= Seq(
       "config.AppConfig",

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val microservice = Project(appName, file("."))
     ScoverageKeys.coverageExcludedFiles :=
       "<empty>;Reverse.*;.*filters.*;.*handlers.*;.*components.*;.*views.html.*;" +
         ".*javascript.*;.*Routes.*;.*GuiceInjector;" +
-        ".*ControllerConfiguration;.*LanguageSwitchController",
+        ".*ControllerConfiguration;.*LanguageSwitchController;.*StartupModule*",
     ScoverageKeys.coverageMinimumStmtTotal := 90,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ resolvers += Resolver.typesafeRepo("releases")
 addSbtPlugin("uk.gov.hmrc"        % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"        % "sbt-distributables"    % "2.6.0")
 addSbtPlugin("org.playframework"  % "sbt-plugin"            % "3.0.8")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage"         % "2.0.9")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"         % "2.3.1")
 addSbtPlugin("io.github.irundaia" % "sbt-sassify"           % "1.5.2")
 addSbtPlugin(
   "org.scalastyle"               %% "scalastyle-sbt-plugin" % "1.0.0"

--- a/test/config/ErrorHandlerSpec.scala
+++ b/test/config/ErrorHandlerSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import play.api.Application
+import play.api.i18n.MessagesApi
+import utils.SpecBase
+import views.html.{ErrorTemplate, not_found}
+import play.api.test.Helpers.*
+import play.twirl.api.Html
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ErrorHandlerSpec extends SpecBase {
+
+  "ErrorHandler" must {
+
+    "return an error page" in new Setup {
+      val result: Html = await(
+        errorHandler.standardErrorTemplate(
+          pageTitle = "pageTitle",
+          heading = "heading",
+          message = "message"
+        )(fakeRequestWithRequestHeader)
+      )
+
+      result.body must include("pageTitle")
+      result.body must include("heading")
+      result.body must include("message")
+    }
+
+    "return notFound template" in new Setup {
+      val result: Html = await(errorHandler.notFoundTemplate(fakeRequestWithRequestHeader))
+
+      result.body must include(messages("cf.error.not-found.heading"))
+      result.body must include(messages("cf.error.not-found.message.address-typed-wrong"))
+      result.body must include(messages("cf.error.not-found.message.address-pasted-wrong"))
+    }
+  }
+
+  trait Setup {
+    val app: Application = applicationBuilder.build()
+
+    implicit val config: AppConfig           = appConfig
+    private val messageApi: MessagesApi      = app.injector.instanceOf[MessagesApi]
+    private val errorTemplate: ErrorTemplate = app.injector.instanceOf[ErrorTemplate]
+    private val notFoundTemplate: not_found  = app.injector.instanceOf[not_found]
+
+    val errorHandler: ErrorHandler = new ErrorHandler(errorTemplate, notFoundTemplate, messageApi)
+  }
+}

--- a/test/connectors/AccountsAndBalancesSpec.scala
+++ b/test/connectors/AccountsAndBalancesSpec.scala
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import utils.SpecBase
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
+import utils.TestData.{
+  accountNumber, dateString, eori, originatingSystem, testAckRef, testRegime, testStatus, testStatusText
+}
+
+class AccountsAndBalancesSpec extends SpecBase {
+
+  "AccountsAndBalancesResponseContainer.returnParametersReads" should {
+    import AccountsAndBalancesResponseContainer.returnParametersReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(returnParamJsString)) mustBe JsSuccess(returnParamOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"status\": \"pending\", \"eventId1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[ReturnParameters]
+      }
+    }
+  }
+
+  "AccountsAndBalancesResponseContainer.accountReads" should {
+    import AccountsAndBalancesResponseContainer.accountReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(accountObJsString)) mustBe JsSuccess(accountOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"number1\": \"123456\", \"owner1\": \"test_owner\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[Account]
+      }
+    }
+  }
+
+  "AccountsAndBalancesResponseContainer.limitsReads" should {
+    import AccountsAndBalancesResponseContainer.limitsReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(limitsObJsString)) mustBe JsSuccess(limitsOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"gaLimit\": \"pending\", \"periodLimit\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[Limits]
+      }
+    }
+  }
+
+  "AccountsAndBalancesResponseContainer.balancesReads" should {
+    import AccountsAndBalancesResponseContainer.balancesReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(defermentBalanceObJsString)) mustBe JsSuccess(defermentBalanceOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"gaAvailBal\": \"1234\", \"accBal\": \"100\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[DefermentBalances]
+      }
+    }
+  }
+
+  "AccountsAndBalancesResponseContainer.generalGuaranteeAccountReads" should {
+    import AccountsAndBalancesResponseContainer.generalGuaranteeAccountReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(generalGuaranteeAccountObJsString)) mustBe JsSuccess(generalGuaranteeAccountOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"acc\": \"pending\", \"gLimit\": \"100\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[GeneralGuaranteeAccount]
+      }
+    }
+  }
+
+  "AccountsAndBalancesResponseContainer.accountResponseDetailReads" should {
+    import AccountsAndBalancesResponseContainer.accountResponseDetailReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(accountResponseDetailObJsString)) mustBe JsSuccess(accountResponseDetailOb)
+    }
+  }
+
+  "AccountsAndBalancesResponseContainer.accountResponseCommonReads" should {
+    import AccountsAndBalancesResponseContainer.accountResponseCommonReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(accountResponseCommonObJsString)) mustBe JsSuccess(accountResponseCommonOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"status1\": \"pending\", \"text\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[AccountResponseCommon]
+      }
+    }
+  }
+
+  "AccountsAndBalancesResponseContainer.accountsAndBalancesResponseReads" should {
+    import AccountsAndBalancesResponseContainer.accountsAndBalancesResponseReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(accountsAndBalancesResponseObJsString)) mustBe JsSuccess(accountsAndBalancesResponseOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"resCom\": \"pending\", \"resDetail\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[AccountsAndBalancesResponse]
+      }
+    }
+  }
+
+  "AccountsAndBalancesResponseContainer.accountsAndBalancesResponseContainerReads" should {
+    import AccountsAndBalancesResponseContainer.accountsAndBalancesResponseContainerReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(accaccountsAndBalancesResponseContainerObountObJsString)) mustBe JsSuccess(
+        accountsAndBalancesResponseContainerOb
+      )
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"accAndBal\": \"pending\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[AccountsAndBalancesResponseContainer]
+      }
+    }
+  }
+
+  "AccountsAndBalancesRequestContainer.accountsRequestCommonFormat" should {
+    import AccountsAndBalancesRequestContainer.accountsRequestCommonFormat
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(accountsRequestCommonObJsString)) mustBe JsSuccess(accountsRequestCommonOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"recDate\": \"2023-08-09\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[AccountsRequestCommon]
+      }
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(accountsRequestCommonOb) mustBe Json.parse(accountsRequestCommonObJsString)
+    }
+  }
+
+  "AccountsAndBalancesRequestContainer.accountsRequestDetailFormat" should {
+    import AccountsAndBalancesRequestContainer.accountsRequestDetailFormat
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(accountsRequestDetailObJsString)) mustBe JsSuccess(accountsRequestDetailOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"eoriNo1\": \"pending\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[AccountsRequestDetail]
+      }
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(accountsRequestDetailOb) mustBe Json.parse(accountsRequestDetailObJsString)
+    }
+  }
+
+  "AccountsAndBalancesRequestContainer.accountsAndBalancesRequestFormat" should {
+    import AccountsAndBalancesRequestContainer.accountsAndBalancesRequestFormat
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(accountsAndBalancesRequestObJsString)) mustBe JsSuccess(accountsAndBalancesRequestOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"reqCom\": \"pending\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[AccountsAndBalancesRequest]
+      }
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(accountsAndBalancesRequestOb) mustBe Json.parse(accountsAndBalancesRequestObJsString)
+    }
+  }
+
+  "AccountsAndBalancesRequestContainer.accountsAndBalancesRequestContainerFormat" should {
+    import AccountsAndBalancesRequestContainer.accountsAndBalancesRequestContainerFormat
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(accountsAndBalancesRequestContainerObJsString)) mustBe JsSuccess(
+        accountsAndBalancesRequestContainerOb
+      )
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"accAndBal\": \"pending\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[AccountsAndBalancesRequestContainer]
+      }
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(accountsAndBalancesRequestContainerOb) mustBe Json.parse(
+        accountsAndBalancesRequestContainerObJsString
+      )
+    }
+  }
+
+  trait Setup {
+    val returnParamOb: ReturnParameters = ReturnParameters("test_param", "test_param_value")
+    val accountOb: Account              = Account("987654", "123456789", "12345678")
+    val limitsOb: Limits                = Limits("100", "100")
+
+    val defermentBalanceOb: DefermentBalances = DefermentBalances("100", "100")
+
+    val generalGuaranteeAccountOb: GeneralGuaranteeAccount =
+      GeneralGuaranteeAccount(accountOb, Some("999"), Some("900"))
+
+    val accountResponseDetailOb: AccountResponseDetail =
+      AccountResponseDetail(Some("123456789"), None, Some(Seq(generalGuaranteeAccountOb)))
+
+    val accountResponseCommonOb: AccountResponseCommon =
+      AccountResponseCommon(testStatus, Some(testStatusText), dateString, Some(Seq(returnParamOb)))
+
+    val accountsAndBalancesResponseOb: AccountsAndBalancesResponse =
+      AccountsAndBalancesResponse(Some(accountResponseCommonOb), accountResponseDetailOb)
+
+    val accountsAndBalancesResponseContainerOb: AccountsAndBalancesResponseContainer =
+      AccountsAndBalancesResponseContainer(accountsAndBalancesResponseOb)
+
+    val accountsRequestCommonOb: AccountsRequestCommon = AccountsRequestCommon(
+      PID = Some("test_id"),
+      originatingSystem = Some(originatingSystem),
+      receiptDate = dateString,
+      acknowledgementReference = testAckRef,
+      regime = testRegime
+    )
+
+    val accountsRequestDetailOb: AccountsRequestDetail = AccountsRequestDetail(
+      EORINo = eori,
+      accountType = Some("CDS Cash"),
+      accountNumber = Some(accountNumber),
+      referenceDate = None
+    )
+
+    val accountsAndBalancesRequestOb: AccountsAndBalancesRequest =
+      AccountsAndBalancesRequest(accountsRequestCommonOb, accountsRequestDetailOb)
+
+    val accountsAndBalancesRequestContainerOb: AccountsAndBalancesRequestContainer =
+      AccountsAndBalancesRequestContainer(accountsAndBalancesRequestOb)
+
+    val returnParamJsString: String = """{"paramName":"test_param","paramValue":"test_param_value"}""".stripMargin
+
+    val accountObJsString: String =
+      """{"number":"987654","type":"123456789","owner":"12345678","viewBalanceIsGranted":false}""".stripMargin
+
+    val limitsObJsString: String = """{"periodGuaranteeLimit":"100","periodAccountLimit":"100"}""".stripMargin
+
+    val defermentBalanceObJsString: String =
+      """{"periodAvailableGuaranteeBalance":"100","periodAvailableAccountBalance":"100"}""".stripMargin
+
+    val generalGuaranteeAccountObJsString: String =
+      """{
+        |"account":{
+        |"number":"987654",
+        |"type":"123456789",
+        |"owner":"12345678",
+        |"viewBalanceIsGranted":false
+        |},
+        |"guaranteeLimit":"999",
+        |"availableGuaranteeBalance":"900"
+        |}""".stripMargin
+
+    val accountResponseDetailObJsString: String =
+      """{
+        |"EORINo":"123456789",
+        |"generalGuaranteeAccount":[
+        |{"account":{
+        |"number":"987654",
+        |"type":"123456789",
+        |"owner":"12345678",
+        |"viewBalanceIsGranted":false},
+        |"guaranteeLimit":"999",
+        |"availableGuaranteeBalance":"900"}]
+        |}""".stripMargin
+
+    val accountResponseCommonObJsString: String =
+      """{
+        |"status":"test_status",
+        |"processingDate":"2020-07-28",
+        |"statusText":"test_status_text",
+        |"returnParameters":[{"paramName":"test_param","paramValue":"test_param_value"}]
+        |}""".stripMargin
+
+    val accountsAndBalancesResponseObJsString: String =
+      """{"responseDetail":{"EORINo":"123456789",
+        |"generalGuaranteeAccount":
+        |[{"account":{
+        |"number":"987654",
+        |"type":"123456789",
+        |"owner":"12345678",
+        |"viewBalanceIsGranted":false
+        |},
+        |"guaranteeLimit":"999",
+        |"availableGuaranteeBalance":"900"}]
+        |},
+        |"responseCommon":
+        |{"status":"test_status",
+        |"processingDate":"2020-07-28",
+        |"statusText":"test_status_text",
+        |"returnParameters":[{"paramName":"test_param","paramValue":"test_param_value"}]}}""".stripMargin
+
+    val accaccountsAndBalancesResponseContainerObountObJsString: String =
+      """{"accountsAndBalancesResponse":
+        |{"responseDetail":{"EORINo":"123456789",
+        |"generalGuaranteeAccount":[{"account":{"number":"987654",
+        |"type":"123456789",
+        |"owner":"12345678",
+        |"viewBalanceIsGranted":false
+        |},
+        |"guaranteeLimit":"999",
+        |"availableGuaranteeBalance":"900"}]
+        |},
+        |"responseCommon":
+        |{"status":"test_status",
+        |"processingDate":"2020-07-28",
+        |"statusText":"test_status_text",
+        |"returnParameters":[{"paramName":"test_param","paramValue":"test_param_value"}]}}
+        |}""".stripMargin
+
+    val accountsRequestCommonObJsString: String =
+      """{
+        |"receiptDate":"2020-07-28",
+        |"regime":"CDS",
+        |"PID":"test_id",
+        |"originatingSystem":"ETMP",
+        |"acknowledgementReference":"123dfeshsfgt34"
+        |}""".stripMargin
+
+    val accountsRequestDetailObJsString: String =
+      """{"EORINo":"GB001","accountType":"CDS Cash","accountNumber":"987654"}""".stripMargin
+
+    val accountsAndBalancesRequestObJsString: String =
+      """{"requestCommon":{
+        |"receiptDate":"2020-07-28",
+        |"regime":"CDS",
+        |"PID":"test_id",
+        |"originatingSystem":"ETMP",
+        |"acknowledgementReference":"123dfeshsfgt34"
+        |},
+        |"requestDetail":{"EORINo":"GB001","accountType":"CDS Cash","accountNumber":"987654"}}""".stripMargin
+
+    val accountsAndBalancesRequestContainerObJsString: String =
+      """{"accountsAndBalancesRequest":
+        |{"requestCommon":
+        |{"receiptDate":"2020-07-28",
+        |"regime":"CDS",
+        |"PID":"test_id",
+        |"originatingSystem":"ETMP",
+        |"acknowledgementReference":"123dfeshsfgt34"
+        |},
+        |"requestDetail":{"EORINo":"GB001","accountType":"CDS Cash","accountNumber":"987654"}}}""".stripMargin
+  }
+}

--- a/test/connectors/FileInformationSpec.scala
+++ b/test/connectors/FileInformationSpec.scala
@@ -16,7 +16,7 @@
 
 package connectors
 
-import play.api.libs.json.Json
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
 import utils.SpecBase
 
 class FileInformationSpec extends SpecBase {
@@ -86,5 +86,65 @@ class FileInformationSpec extends SpecBase {
       val json = Json.toJson(fileInformation)
       json must be(Json.parse(expectedJson))
     }
+  }
+
+  "metadataItemReads" should {
+    "Read the object correctly" in new Setup {
+      import FileInformation.metadataItemReads
+
+      Json.fromJson(Json.parse(metaDataItemInputJsString)) mustBe JsSuccess(metaDataItemObject)
+    }
+
+    "throw exception for invalid Json" in {
+      import FileInformation.metadataItemReads
+      val invalidJson = "{ \"key1\": \"test_key\", \"value1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[MetadataItem]
+      }
+    }
+  }
+
+  "metadataItemWrites" should {
+    "Write the object correctly" in new Setup {
+      import FileInformation.metadataItemWrites
+
+      Json.toJson(metaDataItemObject) mustBe Json.parse(metaDataItemJsString)
+    }
+  }
+
+  "metadataReads" should {
+    "Read the object correctly" in new Setup {
+      import FileInformation.metadataReads
+
+      Json.fromJson(Json.parse(metaDataJsString)) mustBe JsSuccess(metaDataObject)
+    }
+
+    "throw exception for invalid Json" in {
+      import FileInformation.metadataReads
+      val invalidJson = "{ \"item\": \"test_key\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[Metadata]
+      }
+    }
+  }
+
+  "metadataWrites" should {
+    "Write the object correctly" in new Setup {
+      import FileInformation.metadataWrites
+
+      Json.toJson(metaDataObject) mustBe Json.parse(metaDataJsString)
+    }
+  }
+
+  trait Setup {
+    val metaDataItemObject: MetadataItem = MetadataItem("test_key", "test_key_value")
+
+    val metaDataItemJsString: String      = """{"key":"test_key","value":"test_key_value"}""".stripMargin
+    val metaDataItemInputJsString: String = """{"metadata":"test_key","value":"test_key_value"}""".stripMargin
+
+    val metaDataObject: Metadata = Metadata(Seq(MetadataItem("test_key", "test_value")))
+    val metaDataJsString: String = """[{"metadata":"test_key","value":"test_value"}]""".stripMargin
   }
 }

--- a/test/domain/UndeliverableInformationEventSpec.scala
+++ b/test/domain/UndeliverableInformationEventSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package domain
+
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
+
+import utils.SpecBase
+
+class UndeliverableInformationEventSpec extends SpecBase {
+
+  "Writes" should {
+    "generate the correct JsValue" in new Setup {
+      Json.toJson(undelInfoEventOb) mustBe Json.parse(sampleResponse)
+    }
+  }
+
+  "Reads" should {
+    "generate the correct object" in new Setup {
+      import UndeliverableInformationEvent.reads
+
+      Json.fromJson(Json.parse(sampleResponse)) mustBe JsSuccess(undelInfoEventOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"id\": \"test_id\", \"eventId1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[UndeliverableInformationEvent]
+      }
+    }
+  }
+
+  trait Setup {
+    val sampleResponse: String =
+      """{
+        |  "id": "example-id",
+        |  "event": "someEvent",
+        |  "emailAddress": "email@email.com",
+        |  "detected": "2021-05-14T10:59:45.811+01:00",
+        |  "code": 12,
+        |  "reason": "Inbox full",
+        |  "enrolment": "HMRC-CUS-ORG~EORINumber~GB744638982004"
+        |}""".stripMargin
+
+    val eventCode                                       = 12
+    val undelInfoEventOb: UndeliverableInformationEvent = UndeliverableInformationEvent(
+      "example-id",
+      "someEvent",
+      "email@email.com",
+      "2021-05-14T10:59:45.811+01:00",
+      Some(eventCode),
+      Some("Inbox full"),
+      "HMRC-CUS-ORG~EORINumber~GB744638982004"
+    )
+  }
+}

--- a/test/domain/UndeliverableInformationSpec.scala
+++ b/test/domain/UndeliverableInformationSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package domain
+
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
+import utils.SpecBase
+import org.joda.time.DateTime
+import utils.TestData.{day_26, hour_12, minutes_30, month_12, year_2024}
+
+class UndeliverableInformationSpec extends SpecBase {
+
+  "Writes" should {
+    "generate the correct JsValue" in new Setup {
+      Json.toJson(undelInfoOb) mustBe Json.parse(sampleResponse)
+    }
+  }
+
+  "Reads" should {
+    "generate the correct object" in new Setup {
+
+      import UndeliverableInformation.format
+
+      Json.fromJson(Json.parse(sampleResponse)) mustBe JsSuccess(undelInfoOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"id\": \"test_id\", \"eventId1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[UndeliverableInformationEvent]
+      }
+    }
+  }
+
+  trait Setup {
+    val sampleResponse: String =
+      """{
+        |    "subject": "subject-example",
+        |    "eventId": "example-id",
+        |    "groupId": "example-group-id",
+        |    "timestamp": "2024-12-26T12:30:00.000Z",
+        |    "event": {
+        |      "id": "example-id",
+        |      "event": "someEvent",
+        |      "emailAddress": "email@email.com",
+        |      "detected": "2021-05-14T10:59:45.811+01:00",
+        |      "code": 12,
+        |      "reason": "Inbox full",
+        |      "enrolment": "HMRC-CUS-ORG~EORINumber~GB744638982004"
+        |    }
+        |  }""".stripMargin
+
+    val eventCode                                       = 12
+    val undelInfoEventOb: UndeliverableInformationEvent = UndeliverableInformationEvent(
+      "example-id",
+      "someEvent",
+      "email@email.com",
+      "2021-05-14T10:59:45.811+01:00",
+      Some(eventCode),
+      Some("Inbox full"),
+      "HMRC-CUS-ORG~EORINumber~GB744638982004"
+    )
+
+    val undelInfoOb: UndeliverableInformation = UndeliverableInformation(
+      "subject-example",
+      "example-id",
+      "example-group-id",
+      DateTime(year_2024, month_12, day_26, hour_12, minutes_30),
+      undelInfoEventOb
+    )
+  }
+}

--- a/test/models/EmailVerifiedResponseSpec.scala
+++ b/test/models/EmailVerifiedResponseSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{JsSuccess, Json}
+import utils.SpecBase
+import utils.TestData.emailId
+
+class EmailVerifiedResponseSpec extends SpecBase {
+
+  "EmailUnverifiedResponse.format" should {
+    "generate correct output for Json Reads" in new Setup {
+      import EmailUnverifiedResponse.format
+
+      Json.fromJson(Json.parse(emailUnverifiedResJsString)) mustBe JsSuccess(emailUnverifiedResOb)
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(emailUnverifiedResOb) mustBe Json.parse(emailUnverifiedResJsString)
+    }
+  }
+
+  trait Setup {
+    val emailUnverifiedResOb: EmailUnverifiedResponse = EmailUnverifiedResponse(Some(emailId))
+
+    val emailUnverifiedResJsString: String = """{"unVerifiedEmail":"test@test.com"}""".stripMargin
+  }
+}

--- a/test/models/EncryptedGuaranteeTransactionSpec.scala
+++ b/test/models/EncryptedGuaranteeTransactionSpec.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import utils.SpecBase
+
+class EncryptedGuaranteeTransactionSpec extends SpecBase {
+
+  trait Setup {}
+}

--- a/test/models/EncryptedGuaranteeTransactionSpec.scala
+++ b/test/models/EncryptedGuaranteeTransactionSpec.scala
@@ -16,9 +16,223 @@
 
 package models
 
+import uk.gov.hmrc.crypto.Crypted
 import utils.SpecBase
+import utils.TestData.{dateString, encryptedValue, localDate}
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
 
 class EncryptedGuaranteeTransactionSpec extends SpecBase {
 
-  trait Setup {}
+  "amountFormat" should {
+    import EncryptedGuaranteeTransaction.amountFormat
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(encryptedAmountsObJsString)) mustBe JsSuccess(encryptedAmountsOb)
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(encryptedAmountsOb) mustBe Json.parse(encryptedAmountsObJsString)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"totAmount\": \"pending\", \"open\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[EncryptedAmounts]
+      }
+    }
+  }
+
+  "taxTypeFormat" should {
+    import EncryptedGuaranteeTransaction.taxTypeFormat
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(encryptedTaxTypeObJsString)) mustBe JsSuccess(encryptedTaxTypeOb)
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(encryptedTaxTypeOb) mustBe Json.parse(encryptedTaxTypeObJsString)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"totAmount\": \"pending\", \"open\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[EncryptedTaxType]
+      }
+    }
+  }
+
+  "taxTypeGroupFormat" should {
+    import EncryptedGuaranteeTransaction.taxTypeGroupFormat
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(encryptedTaxTypeGroupObJsString)) mustBe JsSuccess(encryptedTaxTypeGroupOb)
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(encryptedTaxTypeGroupOb) mustBe Json.parse(encryptedTaxTypeGroupObJsString)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"totAmount\": \"pending\", \"open\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[EncryptedTaxTypeGroup]
+      }
+    }
+  }
+
+  "dueDateFormat" should {
+    import EncryptedGuaranteeTransaction.dueDateFormat
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(encryptedDueDateObJsString)) mustBe JsSuccess(encryptedDueDateOb)
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(encryptedDueDateOb) mustBe Json.parse(encryptedDueDateObJsString)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"totAmount\": \"pending\", \"open\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[EncryptedDueDate]
+      }
+    }
+  }
+
+  "format" should {
+    import EncryptedGuaranteeTransaction.format
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(encryptedGuaranteeTransactionObJsString)) mustBe JsSuccess(
+        encryptedGuaranteeTransactionOb
+      )
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(encryptedGuaranteeTransactionOb) mustBe Json.parse(encryptedGuaranteeTransactionObJsString)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"totAmount\": \"pending\", \"open\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[EncryptedGuaranteeTransaction]
+      }
+    }
+  }
+
+  trait Setup {
+    val cryptedAmount: Crypted = Crypted("100")
+
+    val encryptedAmountsOb: EncryptedAmounts = EncryptedAmounts(
+      totalAmount = cryptedAmount,
+      clearedAmount = Some(cryptedAmount),
+      openAmount = Some(cryptedAmount),
+      updateDate = cryptedAmount
+    )
+
+    val encryptedTaxTypeOb: EncryptedTaxType = EncryptedTaxType(Crypted("VAT"), encryptedAmountsOb)
+
+    val encryptedTaxTypeGroupOb: EncryptedTaxTypeGroup =
+      EncryptedTaxTypeGroup(Crypted("TAX_GROUP"), encryptedAmountsOb, encryptedTaxTypeOb)
+
+    val encryptedDueDateOb: EncryptedDueDate = EncryptedDueDate(
+      dueDate = Crypted(dateString),
+      reasonForSecurity = Some(Crypted("reason1")),
+      amounts = encryptedAmountsOb,
+      taxTypeGroups = Seq(encryptedTaxTypeGroupOb)
+    )
+
+    val encryptedValueObject: Crypted = Crypted(encryptedValue)
+
+    val encryptedGuaranteeTransactionOb: EncryptedGuaranteeTransaction = EncryptedGuaranteeTransaction(
+      date = localDate,
+      movementReferenceNumber = encryptedValueObject,
+      secureMovementReferenceNumber = None,
+      balance = encryptedValueObject,
+      uniqueConsignmentReference = None,
+      declarantEori = encryptedValueObject,
+      consigneeEori = encryptedValueObject,
+      originalCharge = encryptedValueObject,
+      dischargedAmount = encryptedValueObject,
+      interestCharge = None,
+      c18Reference = None,
+      dueDates = Seq()
+    )
+
+    val encryptedAmountsObJsString: String =
+      """{
+        |"totalAmount":{"value":"100"},
+        |"updateDate":{"value":"100"},
+        |"clearedAmount":{"value":"100"},
+        |"openAmount":{"value":"100"}
+        |}""".stripMargin
+
+    val encryptedTaxTypeObJsString: String =
+      """{
+        |"taxType":{"value":"VAT"},
+        |"amounts":{
+        |"totalAmount":{"value":"100"},
+        |"updateDate":{"value":"100"},
+        |"clearedAmount":{"value":"100"},
+        |"openAmount":{"value":"100"}
+        |}
+        |}""".stripMargin
+
+    val encryptedTaxTypeGroupObJsString: String =
+      """{"taxTypeGroup":
+        |{"value":"TAX_GROUP"},
+        |"amounts":{"totalAmount":{"value":"100"},
+        |"updateDate":{"value":"100"},
+        |"clearedAmount":{"value":"100"},
+        |"openAmount":{"value":"100"}
+        |},"taxType":{"taxType":{"value":"VAT"},
+        |"amounts":{"totalAmount":{"value":"100"},
+        |"updateDate":{"value":"100"},
+        |"clearedAmount":{"value":"100"},
+        |"openAmount":{"value":"100"}
+        |}}}""".stripMargin
+
+    val encryptedDueDateObJsString: String =
+      """{
+        |"dueDate":{"value":"2020-07-28"},
+        |"amounts":{
+        |"totalAmount":{"value":"100"},
+        |"updateDate":{"value":"100"},
+        |"clearedAmount":{"value":"100"},
+        |"openAmount":{"value":"100"}
+        |},
+        |"taxTypeGroups":[{
+        |"taxTypeGroup":{"value":"TAX_GROUP"},
+        |"amounts":{
+        |"totalAmount":{"value":"100"},
+        |"updateDate":{"value":"100"},
+        |"clearedAmount":{"value":"100"},
+        |"openAmount":{"value":"100"}
+        |},
+        |"taxType":{
+        |"taxType":{"value":"VAT"},
+        |"amounts":{
+        |"totalAmount":{"value":"100"},
+        |"updateDate":{"value":"100"},
+        |"clearedAmount":{"value":"100"},
+        |"openAmount":{"value":"100"}
+        |}}}],
+        |"reasonForSecurity":{"value":"reason1"}}""".stripMargin
+
+    val encryptedGuaranteeTransactionObJsString: String =
+      """{
+        |"consigneeEori":{"value":"sTe+0SVx5j5y509Nq8tIyflvnsRMfMC5Ae03fNUEarI="},
+        |"balance":{"value":"sTe+0SVx5j5y509Nq8tIyflvnsRMfMC5Ae03fNUEarI="},
+        |"dischargedAmount":{"value":"sTe+0SVx5j5y509Nq8tIyflvnsRMfMC5Ae03fNUEarI="},
+        |"date":"2024-07-29",
+        |"originalCharge":{"value":"sTe+0SVx5j5y509Nq8tIyflvnsRMfMC5Ae03fNUEarI="},
+        |"declarantEori":{"value":"sTe+0SVx5j5y509Nq8tIyflvnsRMfMC5Ae03fNUEarI="},
+        |"movementReferenceNumber":{"value":"sTe+0SVx5j5y509Nq8tIyflvnsRMfMC5Ae03fNUEarI="},
+        |"dueDates":[]}""".stripMargin
+  }
 }

--- a/test/models/GuaranteeAccountSpec.scala
+++ b/test/models/GuaranteeAccountSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import utils.SpecBase
+import utils.TestData.{eighteen, twoThousand}
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
+
+class GuaranteeAccountSpec extends SpecBase {
+
+  "usedFunds" should {
+    "return correct value" in {
+      val expectedResult = 1982
+
+      GeneralGuaranteeBalance(BigDecimal(twoThousand), BigDecimal(eighteen)).usedFunds mustBe BigDecimal(expectedResult)
+    }
+  }
+
+  "usedPercentage" should {
+    "return correct value" in {
+      val expectedPercentage = 99.100
+
+      GeneralGuaranteeBalance(BigDecimal(twoThousand), BigDecimal(eighteen)).usedPercentage mustBe BigDecimal(
+        expectedPercentage
+      )
+    }
+  }
+
+  "GeneralGuaranteeBalance.format" should {
+    "generate correct output for Json Reads" in new Setup {
+      import GeneralGuaranteeBalance.format
+
+      Json.fromJson(Json.parse(ggBalanceObJsString)) mustBe JsSuccess(ggBalanceOb)
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(ggBalanceOb) mustBe Json.parse(ggBalanceObJsString)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"gaLimit\": \"100\", \"avlBalance\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[GeneralGuaranteeBalance]
+      }
+    }
+  }
+
+  trait Setup {
+    val ggBalanceOb: GeneralGuaranteeBalance = GeneralGuaranteeBalance(BigDecimal(twoThousand), BigDecimal(twoThousand))
+    val ggBalanceObJsString: String          = """{"GuaranteeLimit":2000,"AvailableGuaranteeBalance":2000}""".stripMargin
+  }
+}

--- a/test/models/GuaranteeTransactionDatesSpec.scala
+++ b/test/models/GuaranteeTransactionDatesSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import utils.SpecBase
+import utils.TestData.{fromDate, toDate}
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
+
+class GuaranteeTransactionDatesSpec extends SpecBase {
+
+  "format" should {
+    "generate correct output for Json Reads" in new Setup {
+      import GuaranteeTransactionDates.format
+
+      Json.fromJson(Json.parse(ggTransDatesJsString)) mustBe JsSuccess(ggTransDatesOb)
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(ggTransDatesOb) mustBe Json.parse(ggTransDatesJsString)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"fromD\": \"pending\", \"toDate1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[GuaranteeTransactionDates]
+      }
+    }
+  }
+
+  trait Setup {
+    val ggTransDatesOb: GuaranteeTransactionDates = GuaranteeTransactionDates(fromDate, toDate)
+
+    val ggTransDatesJsString: String = """{"start":"2020-10-20","end":"2020-12-22"}""".stripMargin
+  }
+}

--- a/test/models/GuaranteeTransactionSpec.scala
+++ b/test/models/GuaranteeTransactionSpec.scala
@@ -138,7 +138,7 @@ class GuaranteeTransactionSpec extends SpecBase {
     }
 
     "return None when reasonForSecurity and taxTypeGroups are empty " in new Setup {
-      ddNoTaxTypeGroups.copy(reasonForSecurity = None, taxTypeGroups = None).securityReason mustBe empty
+      ddNoTaxTypeGroups.copy(reasonForSecurity = None, taxTypeGroups = Seq()).securityReason mustBe empty
     }
   }
 

--- a/test/models/GuaranteeTransactionSpec.scala
+++ b/test/models/GuaranteeTransactionSpec.scala
@@ -17,23 +17,214 @@
 package models
 
 import utils.SpecBase
+import utils.TestData.localDate
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
 
 class GuaranteeTransactionSpec extends SpecBase {
 
-  val amt = Amounts("20.00", Some("30.00"), Some("10.00"), "2020-08-01")
-  val tt  = TaxType("VAT", amt)
-  val ttg = TaxTypeGroup(taxTypeGroup = "VAT", amounts = amt, taxType = tt)
-  val dd  = DueDate(dueDate = "2020-07-28", reasonForSecurity = Some("T24"), amounts = amt, taxTypeGroups = Seq(ttg))
+  "GuaranteeTransaction.fieldNames" should {
 
-  val ddNoTaxTypeGroups =
-    DueDate(dueDate = "2020-07-28", reasonForSecurity = Some("T24"), amounts = amt, taxTypeGroups = Seq.empty)
+    "return the correct result" in new Setup {
+      ggTransactionOb.fieldNames mustBe Seq(
+        "date",
+        "movementReferenceNumber",
+        "secureMovementReferenceNumber",
+        "balance",
+        "uniqueConsignmentReference",
+        "declarantEori",
+        "consigneeEori",
+        "originalCharge",
+        "dischargedAmount",
+        "interestCharge",
+        "c18Reference",
+        "dueDates"
+      )
+    }
+  }
+
+  "GuaranteeTransaction.moreThanOne" should {
+    "return the correct result" in new Setup {
+      ggTransactionOb.moreThanOne mustBe false
+    }
+  }
+
+  "GuaranteeTransaction.amountReads" should {
+    import GuaranteeTransaction.amountReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(amountsObJsString)) mustBe JsSuccess(amountsOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"fromD\": \"pending\", \"toDate1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[Amounts]
+      }
+    }
+  }
+
+  "GuaranteeTransaction.taxTypeReads" should {
+    import GuaranteeTransaction.taxTypeReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(taxTypeObJsString)) mustBe JsSuccess(taxTypeOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"fromD\": \"pending\", \"toDate1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[TaxType]
+      }
+    }
+  }
+
+  "GuaranteeTransaction.taxTypeGroupReads" should {
+    import GuaranteeTransaction.taxTypeGroupReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(taxTypeGroupObJsString)) mustBe JsSuccess(taxTypeGroupOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"fromD\": \"pending\", \"toDate1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[TaxTypeGroup]
+      }
+    }
+  }
+
+  "GuaranteeTransaction.dueDateReads" should {
+    import GuaranteeTransaction.dueDateReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(dueDateObJsString)) mustBe JsSuccess(dueDateOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"fromD\": \"pending\", \"toDate1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[DueDate]
+      }
+    }
+  }
+
+  "GuaranteeTransaction.guaranteeTransactionReads" should {
+    import GuaranteeTransaction.guaranteeTransactionReads
+
+    "generate correct output for Json Reads" in new Setup {
+      Json.fromJson(Json.parse(ggTransactionObJsString)) mustBe JsSuccess(ggTransactionOb)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"date1\": \"2023-01-19\", \"ref\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[GuaranteeTransaction]
+      }
+    }
+  }
 
   "getSecurityReason" should {
-    "return None when dueDates are empty " in {
-      ddNoTaxTypeGroups.securityReason mustBe None
+    "return None when dueDates are empty " in new Setup {
+      ddNoTaxTypeGroups.securityReason mustBe empty
     }
-    "return security reason  when dueDates are not empty " in {
-      Some(dd.securityReason.get.taxCode) mustBe dd.reasonForSecurity
+
+    "return security reason  when dueDates are not empty " in new Setup {
+      Some(dueDateOb.securityReason.get.taxCode) mustBe dueDateOb.reasonForSecurity
     }
+
+    "return None when reasonForSecurity and taxTypeGroups are empty " in new Setup {
+      ddNoTaxTypeGroups.copy(reasonForSecurity = None, taxTypeGroups = None).securityReason mustBe empty
+    }
+  }
+
+  trait Setup {
+    val amountsOb: Amounts = Amounts("20.00", Some("30.00"), Some("10.00"), "2020-08-01")
+    val taxTypeOb: TaxType = TaxType("VAT", amountsOb)
+
+    val taxTypeGroupOb: TaxTypeGroup = TaxTypeGroup(taxTypeGroup = "VAT", amounts = amountsOb, taxType = taxTypeOb)
+
+    val dueDateOb: DueDate = DueDate(
+      dueDate = "2020-07-28",
+      reasonForSecurity = Some("T24"),
+      amounts = amountsOb,
+      taxTypeGroups = Seq(taxTypeGroupOb)
+    )
+
+    val ddNoTaxTypeGroups: DueDate =
+      DueDate(dueDate = "2020-07-28", reasonForSecurity = Some("T24"), amounts = amountsOb, taxTypeGroups = Seq.empty)
+
+    val ggTransactionOb: GuaranteeTransaction = GuaranteeTransaction(
+      localDate,
+      "19GB000056HG5w746",
+      None,
+      BigDecimal(45367.12),
+      Some("MGH-500000"),
+      "GB10000",
+      "GB20000",
+      BigDecimal(21.00),
+      BigDecimal(11.50),
+      None,
+      None,
+      dueDates = Seq(dueDateOb)
+    )
+
+    val amountsObJsString: String =
+      """{"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"}""".stripMargin
+
+    val taxTypeObJsString: String =
+      """{"taxType":"VAT",
+        |"amounts":{
+        |"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"
+        |}
+        |}""".stripMargin
+
+    val taxTypeGroupObJsString: String =
+      """{
+        |"taxTypeGroup":"VAT",
+        |"amounts":{"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"},
+        |"taxType":{
+        |"taxType":"VAT",
+        |"amounts":{"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"}
+        |}
+        |}""".stripMargin
+
+    val dueDateObJsString: String =
+      """{
+        |"dueDate":"2020-07-28",
+        |"amounts":{"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"},
+        |"taxTypeGroups":[
+        |{
+        |"taxTypeGroup":"VAT",
+        |"amounts":{"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"},
+        |"taxType":{
+        |"taxType":"VAT",
+        |"amounts":{"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"}}}],
+        |"reasonForSecurity":"T24"}""".stripMargin
+
+    val ggTransactionObJsString: String =
+      """{
+        |"consigneeEori":"GB20000",
+        |"balance":45367.12,
+        |"dischargedAmount":11.5,
+        |"originalCharge":21,
+        |"declarantEori":"GB10000",
+        |"movementReferenceNumber":"19GB000056HG5w746",
+        |"dueDates":[
+        |{"dueDate":"2020-07-28",
+        |"amounts":{"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"},
+        |"taxTypeGroups":[
+        |{"taxTypeGroup":"VAT",
+        |"amounts":{"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"},
+        |"taxType":{
+        |"taxType":"VAT",
+        |"amounts":{"totalAmount":"20.00","updateDate":"2020-08-01","clearedAmount":"30.00","openAmount":"10.00"}}}
+        |],
+        |"reasonForSecurity":"T24"}],"date":"2024-07-29","uniqueConsignmentReference":"MGH-500000"}""".stripMargin
+
   }
 }

--- a/test/models/RequestDatesSpec.scala
+++ b/test/models/RequestDatesSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import utils.SpecBase
+import play.api.libs.json.{JsResultException, JsSuccess, Json}
+import utils.TestData.{fromDate, toDate}
+
+class RequestDatesSpec extends SpecBase {
+
+  "format" should {
+    "generate correct output for Json Reads" in new Setup {
+      import RequestDates.requestDates
+
+      Json.fromJson(Json.parse(requestDatesJsString)) mustBe JsSuccess(requestDatesOb)
+    }
+
+    "generate correct output for Json Writes" in new Setup {
+      Json.toJson(requestDatesOb) mustBe Json.parse(requestDatesJsString)
+    }
+
+    "throw exception for invalid Json" in {
+      val invalidJson = "{ \"fromD\": \"pending\", \"toDate1\": \"test_event\" }"
+
+      intercept[JsResultException] {
+        Json.parse(invalidJson).as[RequestDates]
+      }
+    }
+  }
+
+  trait Setup {
+    val requestDatesOb: RequestDates = RequestDates(fromDate, toDate)
+    val requestDatesJsString: String = """{"dateFrom":"2020-10-20","dateTo":"2020-12-22"}""".stripMargin
+  }
+}

--- a/test/services/DataStoreServiceSpec.scala
+++ b/test/services/DataStoreServiceSpec.scala
@@ -21,7 +21,7 @@ import models.UnverifiedEmail
 import org.joda.time.DateTime
 import org.mockito.invocation.InvocationOnMock
 import play.api.{Application, inject}
-import play.api.libs.json.{JsSuccess, Json}
+import play.api.libs.json.Json
 import play.api.test.Helpers.*
 import uk.gov.hmrc.auth.core.retrieve.Email
 import uk.gov.hmrc.http.{HttpReads, ServiceUnavailableException, UpstreamErrorResponse}

--- a/test/services/DataStoreServiceSpec.scala
+++ b/test/services/DataStoreServiceSpec.scala
@@ -134,11 +134,16 @@ class DataStoreServiceSpec extends SpecBase {
     "create the object correctly for Json Reads" in new Setup {
       import EmailResponse.format
 
-      Json.fromJson(Json.parse(sampleEmailResponse)) mustBe JsSuccess(emailResponseObject)
+      val emailResOb: EmailResponse = Json.parse(sampleEmailResponse).as[EmailResponse]
+
+      emailResOb.address mustBe Some("john.doe@example.com")
     }
 
     "generate the correct output for Json Writes" in new Setup {
-      Json.toJson(emailResponseObject) mustBe Json.parse(sampleEmailResponse)
+      val emailResponseResultString: String = Json.toJson(emailResponseObject).toString
+
+      assert(emailResponseResultString.contains("john.doe@example.com"))
+      assert(emailResponseResultString.contains("email@email.com"))
     }
   }
 
@@ -174,7 +179,7 @@ class DataStoreServiceSpec extends SpecBase {
         |"reason":"Inbox full"
         |},
         |"subject":"subject-example",
-        |"timestamp":"2024-07-26T01:02:00.000+01:00",
+        |"timestamp":"2024-07-26T01:02:00.000Z",
         |"eventId":"example-id",
         |"groupId":"example-group-id"
         |}

--- a/test/utils/SpecBase.scala
+++ b/test/utils/SpecBase.scala
@@ -72,6 +72,8 @@ trait SpecBase
   def fakeRequest(method: String = emptyString, path: String = emptyString): FakeRequest[AnyContentAsEmpty.type] =
     FakeRequest(method, path).withCSRFToken.asInstanceOf[FakeRequest[AnyContentAsEmpty.type]]
 
+  def fakeRequestWithRequestHeader: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+
   implicit lazy val messages: Messages = instanceOf[MessagesApi].preferred(fakeRequest(emptyString, singleSpace))
 
   lazy val application: Application = applicationBuilder.build()
@@ -80,7 +82,7 @@ trait SpecBase
 
   lazy implicit val hc: HeaderCarrier = HeaderCarrier(sessionId = Some(sessionId))
 
-  lazy val bodyParsers = applicationBuilder.injector().instanceOf[BodyParsers.Default]
+  lazy val bodyParsers: BodyParsers.Default = applicationBuilder.injector().instanceOf[BodyParsers.Default]
 
   lazy val mockHttpClient: HttpClientV2 = mock[HttpClientV2]
 

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -81,4 +81,16 @@ object TestData {
   val encryptedValue     = "sTe+0SVx5j5y509Nq8tIyflvnsRMfMC5Ae03fNUEarI="
   val nonceValue: String = "RosGoD7PB/RGTz9uYEvU86zB/LxuWRUGQ2ay9PYbqWBKgy1Jy+j+REmx+cp74VhtvTrfFttQv4ArHUc/1tMyl3" +
     "fGz3/cr8Tm1BHzanv659kI2MJqMynltIsY9fqdDpmO"
+
+  val testStatus     = "test_status"
+  val testStatusText = "test_status_text"
+
+  val dateString = "2020-07-28"
+
+  val originatingSystem = "ETMP"
+  val testAckRef        = "123dfeshsfgt34"
+  val testRegime        = "CDS"
+
+  val emailId       = "test@test.com"
+  val testReference = "123fghs7y#"
 }


### PR DESCRIPTION
Description - Increase test coverage to at-least 90%

Below have been done as part of this PR

- [x] Added tests for models to address Json.Format
- [x] add more tests for existing classes
- [x] upgrade scoverage version to 2.3.1
- [x] coverageFailOnMinimum flag has been enabled
- [x] suppress platform generated css warnings
- [x] minor indentation update (scala formatting) in two files in normal code 
- [x] Platform version has not been updated to 9.16.0 on purpose, to avoid the (existing) performance tests issue with version 9.16.0